### PR TITLE
Change 'project_name' to be required when creating project from template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
-        run: cookiecutter --no-input ssb-pypitemplate 'project_name'='ssb-library'
+        run: cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
       - name: Create git repository
         if: matrix.os != 'windows-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
-        run: cookiecutter --no-input ssb-pypitemplate
+        run: cookiecutter --no-input ssb-pypitemplate 'project_name'='ssb-library'
       - name: Create git repository
         if: matrix.os != 'windows-latest'
         run: |

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "project_name": "ssb-library",
+  "project_name": null,
   "package_name": "{{ cookiecutter.project_name.replace('-', '_') }}",
   "friendly_name": "{{ cookiecutter.project_name.replace('-', ' ').title().replace('Ssb', 'SSB') }}",
   "copyright_owner": "Statistics Norway",

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -236,7 +236,7 @@ Here is a complete list of the project variables defined by this template:
   - Example
 - - `project_name`
   - Project name on PyPI and GitHub repo name
-  - null
+  - `ssb_library`
 - - `package_name`
   - Import name of the package
   - `ssb_library`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -236,7 +236,7 @@ Here is a complete list of the project variables defined by this template:
   - Example
 - - `project_name`
   - Project name on PyPI and GitHub repo name
-  - `ssb_library`
+  - `ssb-library`
 - - `package_name`
   - Import name of the package
   - `ssb_library`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -236,7 +236,7 @@ Here is a complete list of the project variables defined by this template:
   - Example
 - - `project_name`
   - Project name on PyPI and GitHub repo name
-  - `ssb-library`
+  - null
 - - `package_name`
   - Import name of the package
   - `ssb_library`


### PR DESCRIPTION
This change causes the user to be repeatedly prompted if one doesn't specify the "project_name". Whereas previously, the default "ssb-library" was used