### PR TITLE
Ignore Ruff D102 & D101 in tests

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -133,6 +133,7 @@ classmethod-decorators = ["classmethod", "validator", "root_validator", "pydanti
     # return annotations don't add value for test functions
     "ANN201",
     # docstrings are overkill for test functions
+    "D102",
     "D103",
     "D100",
 ]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -133,6 +133,7 @@ classmethod-decorators = ["classmethod", "validator", "root_validator", "pydanti
     # return annotations don't add value for test functions
     "ANN201",
     # docstrings are overkill for test functions
+    "D101",
     "D102",
     "D103",
     "D100",


### PR DESCRIPTION
When creating test classes in tests, documenting the class methods and the class itself is overkill. Same principle as the other "D1xx" cases we ignore.

Cases are documented here: 
D102: https://docs.astral.sh/ruff/rules/undocumented-public-method/
D101: https://docs.astral.sh/ruff/rules/undocumented-public-class/