### PR TITLE
Install root package with Poetry when building docs

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --no-root
+          poetry install
 
       - name: Build doc with Sphinx
         run: |


### PR DESCRIPTION
This PR changes the "docs.yml" workflow to install the root Python package (note: not the root user). We noticed some strange Sphinx error messages with documentation not being built when run in GHA, seen in [dapla-toolbelt-pseudo](https://github.com/statisticsnorway/dapla-toolbelt-pseudo/actions/runs/7640112601/job/20814546789), and [datadoc](https://github.com/statisticsnorway/datadoc/actions/runs/7624662082/job/20767293429). To be honest, I am not proficient enough with Sphinx to know what exactly is the root (hehe) cause - but building Sphinx docs locally with `poetry run sphinx-build -W docs docs/_build` showed no errors. In contrast, running the same commands as the `docs.yml` workflow locally *does* produce the error.

Hopefully this PR fixes the issue for others.