### PR TITLE
Fix issue #48: Missing coverage reports in SonarCloud

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           subprocess.run(cmd, shell=True)
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit
@@ -157,7 +157,9 @@ jobs:
       # Need to fix coverage source paths for SonarCloud scanning in GitHub actions.
       # Replace root path with /github/workspace (mounted in docker container).
       - name: Override coverage source paths for SonarCloud
-        run: sed -i "s/<source>\/home\/runner\/work\/{{cookiecutter.project_name}}\/{{cookiecutter.project_name}}/<source>\/github\/workspace/g" coverage.xml
+        run: |
+          sed -i "s/<source><\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
+          sed -i "s/<source>tests/<source>\/github\/workspace\/tests/g" coverage.xml
 
       - name: SonarCloud Scan
         env:


### PR DESCRIPTION
After the change to use relative paths when running coverage, the override coverage source paths for SonarCloud in test.yml needed to be updated.