### PR TITLE
Update ruff config for type annotations and fix a doc publishing problem

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build doc with Sphinx
         run: |
-          poetry run sphinx-build -W docs docs/_build
+          poetry run sphinx-build docs docs/_build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -1,4 +1,5 @@
 """Sphinx configuration."""
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -1,4 +1,5 @@
 """Nox sessions."""
+
 import os
 import shlex
 import shutil

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -76,13 +76,23 @@ force-exclude = true  # Apply excludes to pre-commit
 show-fixes = true
 src = ["src", "tests"]
 target-version = "py39"  # Minimum Python version supported
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+extend-exclude = [
+    "__pycache__",
+    "old",
+    ".ipynb_checkpoints",
+    "noxfile.py",
+    "docs/conf.py",
+]
 
 # Ruff rules may be customized as desired: https://docs.astral.sh/ruff/rules/
+[tool.ruff.lint]
 {% if cookiecutter.code_quality_level == "High" %}
 select = ["ALL"]
 {% elif cookiecutter.code_quality_level == "Medium" %}
 select = [
     "A",    # prevent using keywords that clobber python builtins
+    "ANN",  # check type annotations
     "B",    # bugbear: security warnings
     "D",    # documentation
     "E",    # pycodestyle
@@ -100,40 +110,41 @@ select = [
 {% endif %}
 ignore = [
     "ANN101", # Supress missing-type-self.
+    "ANN102", # Supress missing-type-cls.
+    "ANN202", # Don't requiere return type annotation for private functions.
+    "ANN401", # Allow type annotation with type Any.
     "D100",   # Supress undocumented-public-module. Only doc of public api required.
     "E402",   # Supress module-import-not-at-top-of-file, needed in jupyter notebooks.
     "E501",   # Supress line-too-long warnings: trust black's judgement on this one.
 ]
-include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
-extend-exclude = [
-    "__pycache__",
-    "old",
-    ".ipynb_checkpoints",
-    "noxfile.py",
-    "docs/conf.py",
-]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 15
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"  # You can also use "numpy".
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 classmethod-decorators = ["classmethod", "validator", "root_validator", "pydantic.validator"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
 "**/tests/*" = [
-    "S101",    # asserts are encouraged in pytest
-    "ANN201",  # return annotations don't add value for test functions
+    "ANN001",  # type annotations don't add value for test functions
+    "ANN002",  # type annotations don't add value for test functions
+    "ANN003",  # type annotations don't add value for test functions
+    "ANN201",  # type annotations don't add value for test functions
+    "ANN204",  # type annotations don't add value for test functions
+    "ANN205",  # type annotations don't add value for test functions
+    "ANN206",  # type annotations don't add value for test functions
     "D100",    # docstrings are overkill for test functions
     "D101",
     "D102",
     "D103",
+    "S101",    # asserts are encouraged in pytest
 ]
 
 [build-system]

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
@@ -1,4 +1,5 @@
 """Command-line interface."""
+
 import click
 
 

--- a/{{cookiecutter.project_name}}/tests/test_main.py
+++ b/{{cookiecutter.project_name}}/tests/test_main.py
@@ -1,4 +1,5 @@
 """Test cases for the __main__ module."""
+
 import pytest
 from click.testing import CliRunner
 


### PR DESCRIPTION
 Require type annotations in source code for medium quality level
 - Allow missing type hints in test code
 - Update ruff config to latest syntax described on the ruff homepage

Don't treat warnings as errors in sphinx-build when publishing docs
- Adjust the docs.yml GitHub Action to not treat warning as errors.
  The docs_build nox session does not treat warning as errors, and
  then the GitHub Action for publishing should do the same.

Update code formatting according to black version 24