### PR TITLE
Release 2024.1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in [Statistics Norway].
 Use [Cruft] to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.18
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.26
 ```
 
 Cruft downloads the template, and asks you a series of questions about project variables,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ Here is a detailed list of features for this Python template:
 
 The {{ SPT }} uses [Calendar Versioning] with a `YYYY.MM.DD` versioning scheme.
 
-The current stable release is [2024.1.18].
+The current stable release is [2024.1.26].
 
 (installation)=
 
@@ -212,10 +212,10 @@ pipx upgrade poetry
 
 Create a project from this template
 by pointing Cruft to its [GitHub repository][ssb pypi template].
-Use the `--checkout` option with the [current stable release][2024.1.18]:
+Use the `--checkout` option with the [current stable release][2024.1.26]:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.18
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.26
 ```
 
 Cruft downloads the template,
@@ -2570,7 +2570,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [.github/dependabot.yml]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 [.gitignore]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [.readthedocs.yml]: https://docs.readthedocs.io/en/stable/config-file/v2.html
-[2024.1.18]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2024.1.18
+[2024.1.26]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2024.1.26
 [__main__]: https://docs.python.org/3/library/__main__.html
 [abstract syntax tree]: https://docs.python.org/3/library/ast.html
 [actions/cache]: https://github.com/actions/cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ and adopted for use in [Statistics Norway].
 Use [Cruft](https://cruft.github.io/cruft/) to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.18
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.26
 ```
 
 To check if there are there are template updates and update your instance with

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ It is recommended to set up Python 3.9, 3.10 and 3.11 using [pyenv].
 Generate a Python project:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.18
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2024.1.26
 ```
 
 Cruft downloads the template and asks you a series of questions about project variables.


### PR DESCRIPTION
## Changes

* Update GitHub Actions to use cache@v4 (#54) @arneso-ssb
* Add tooling install instructions to contributor guide (#51) @mmwinther
* Install root package with Poetry when building docs (#50) @mallport

## :rocket: Features

* Update ruff config for type annotations and fix a doc publishing problem (#53) @arneso-ssb

## :beetle: Fixes

* Fix issue #48: Missing coverage reports in SonarCloud (#52) @arneso-ssb
