### PR TITLE
Use absolute paths when referencing files in GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip install --constraint=.github/workflows/constraints.txt nox
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
       - name: Build documentation
         run: nox --force-color --session=docs
       - name: Upload artifact

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip install --constraint=.github/workflows/constraints.txt pre-commit
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pre-commit
       - name: Compute cache key prefix
         if: matrix.os != 'windows-latest'
         id: cache_key_prefix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
       - name: Create poetry.lock file
@@ -98,8 +98,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip install --constraint=.github/workflows/constraints.txt nox
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
       - name: Build documentation
         run: nox --force-color --session=docs
       - name: Check links

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          root_workspace=${{ github.workspace }}
-          pip install --constraint=${root_workspace%/*}/.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt poetry
+          ls ${{ github.workspace }}
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
-        working-directory: ssb-pypitemplate
+        working-directory: ${{ github.workspace }}/ssb-pypitemplate
         run: |
-          pip install --constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt pip
+          pwd
+          pip install --constraint=.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox nox-poetry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
-          cd ssb-pypitemplate
+          ls
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
       - name: Create poetry.lock file
         run: poetry update --lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,16 +29,11 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          pwd
-          ls -al ${{ github.workspace }}
-          ls -al ${{ github.workspace }}/ssb-pypitemplate/
-          ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/
-          ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/workflows/
           pip install --constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
-        working-directory: ssb-pypitemplate
         run: |
           pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
         working-directory: ${{ github.workspace }}/ssb-pypitemplate
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
-        working-directory: ssb-pypitemplate
         run: |
           pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: ssb-pypitemplate
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
+        working-directory: ssb-pypitemplate
         run: |
           pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,9 @@ jobs:
         working-directory: ssb-pypitemplate
         run: |
           ls -al ${{ github.workspace }}
-          ls -al ${{ github.workspace }}/.github/
-          ls -al ${{ github.workspace }}/.github/workflows/
+          ls -al ${{ github.workspace }}/ssb-pypitemplate/
+          ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/
+          ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/workflows/
           pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,11 @@ jobs:
       - name: Install tools using pip
         working-directory: ${{ github.workspace }}/ssb-pypitemplate
         run: |
-          pwd
           pip install --constraint=.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt poetry
+          pipx install --pip-args=--constraint=.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,12 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          root_workspace=$(${{ github.workspace }} | sed 's|.*/||')
-          echo $root_workspace
-          pip install --constraint=${root_workspace}/.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt poetry
+          root_workspace=${{ github.workspace }}
+          pip install --constraint=${root_workspace%/*}/.github/workflows/constraints.txt pip
+          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${root_workspace%/*}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          pip install --constraint=$GITHUB_WORKSPACE/.github/workflows/constraints.txt pip
+          root_workspace=$(${{ github.workspace }} | sed 's|.*/||')
+          pip install --constraint=${root_workspace}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,12 @@ jobs:
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
+          pwd
           ls -al ${{ github.workspace }}
           ls -al ${{ github.workspace }}/ssb-pypitemplate/
           ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/
           ls -al ${{ github.workspace }}/ssb-pypitemplate/.github/workflows/
-          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-           path: ssb-pypitemplate
+          path: ssb-pypitemplate
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
         working-directory: ssb-pypitemplate
         run: |
-          ls ${{ github.workspace }}
+          ls -al ${{ github.workspace }}
+          ls -al ${{ github.workspace }}/.github/
+          ls -al ${{ github.workspace }}/.github/workflows/
           pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
         working-directory: ssb-pypitemplate
         run: |
           root_workspace=$(${{ github.workspace }} | sed 's|.*/||')
+          echo $root_workspace
           pip install --constraint=${root_workspace}/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,10 @@ jobs:
         run: |
           root_workspace=$(${{ github.workspace }} | sed 's|.*/||')
           pip install --constraint=${root_workspace}/.github/workflows/constraints.txt pip
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
-          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt cookiecutter
+          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args=--constraint=${root_workspace}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,9 @@ jobs:
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
-        run: cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
+        run: |
+          cd ssb-pypitemplate
+          cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
       - name: Create poetry.lock file
         run: poetry update --lock
         working-directory: ssb-library

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,19 +21,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+           path: ssb-pypitemplate
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
+        working-directory: ssb-pypitemplate
         run: |
-          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install --constraint=$GITHUB_WORKSPACE/.github/workflows/constraints.txt pip
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt cookiecutter
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
       - name: Generate project using Cookiecutter
         run: |
-          ls
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library
       - name: Create poetry.lock file
         run: poetry update --lock

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -27,12 +27,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c '${{ github.workspace }}'/.github/workflows/constraints.txt" poetry
           poetry --version
-
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
 {% endraw %}
+
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c .github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ github.workspace }}.github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Set up Python

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -27,10 +27,12 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
+{% raw %}
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c '${{ github.workspace }}'/.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
+{% endraw %}
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install -c .github/workflows/constraints.txt pip
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pip install -c .github/workflows/constraints.txt poetry
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
           poetry --version
 
       - name: Check if there is a parent commit

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
           poetry --version
 {% endraw %}
+
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -24,17 +24,18 @@ jobs:
         uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.12"
-
+{% raw %}
       - name: Upgrade pip
         run: |
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
-
+{% endraw %}
+{% raw %}
       - name: Install Poetry
         run: |
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
           poetry --version
-
+{% endraw %}
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 {% endraw %}
+
       - name: Upgrade pip in virtual environments
         shell: python
         run: |
@@ -68,6 +69,7 @@ jobs:
           pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 {% endraw %}
+
       - name: Compute pre-commit cache key
         if: matrix.session == 'pre-commit'
         id: pre-commit-cache
@@ -143,6 +145,7 @@ jobs:
           pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 {% endraw %}
+
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install -c .github/workflows/constraints.txt pip
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Upgrade pip in virtual environments
@@ -58,13 +58,13 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c .github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args "-c .github/workflows/constraints.txt" nox
-          pipx inject --pip-args "-c .github/workflows/constraints.txt" nox nox-poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 
       - name: Compute pre-commit cache key
@@ -126,18 +126,18 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install -c .github/workflows/constraints.txt pip
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c .github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args "-c .github/workflows/constraints.txt" nox
-          pipx inject --pip-args "-c .github/workflows/constraints.txt" nox nox-poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 
       - name: Download coverage data

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -41,12 +41,12 @@ jobs:
         uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{"{{"}} matrix.python {{"}}"}}
-
+{% raw %}
       - name: Upgrade pip
         run: |
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
-
+{% endraw %}
       - name: Upgrade pip in virtual environments
         shell: python
         run: |
@@ -55,18 +55,19 @@ jobs:
 
           with open(os.environ["GITHUB_ENV"], mode="a") as io:
               print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
-
+{% raw %}
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
-
+{% endraw %}
+{% raw %}
       - name: Install Nox
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
           pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
-
+{% endraw %}
       - name: Compute pre-commit cache key
         if: matrix.session == 'pre-commit'
         id: pre-commit-cache
@@ -123,23 +124,25 @@ jobs:
         uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.12"
-
+{% raw %}
       - name: Upgrade pip
         run: |
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
-
+{% endraw %}
+{% raw %}
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
-
+{% endraw %}
+{% raw %}
       - name: Install Nox
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
           pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
-
+{% endraw %}
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
All GHA workflows using this template have started randomly failing yesterday, with the error:
`ERROR: Could not open requirements file: [Errno 2] No such file or directory: '.github/workflows/constraints.txt'`

No idea why this happens, but changing the paths to absolute instead of relative fixes the issue.

Examples of repos where this has been happening:
https://github.com/statisticsnorway/dapla-toolbelt-pseudo/actions/runs/8535556405/job/23382201774
https://github.com/statisticsnorway/datadoc/actions/runs/8551480041/job/23430574692
https://github.com/statisticsnorway/ssb-klass-python/actions/runs/8537434661/job/23388004250