### PR TITLE
Fix missing coverage upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
       - run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     name: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ssb-pypitemplate
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tools using pip
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "^{{cookiecutter\\.project_name}}/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 furo==2024.8.6
 myst-parser==4.0.0
 sphinx==8.0.2
-sphinx-autobuild==2024.4.16
+sphinx-autobuild==2024.9.3
 sphinx-copybutton==0.5.2

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
 {% endraw %}
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
           cache: "poetry"

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
 {% raw %}
@@ -63,11 +63,11 @@ jobs:
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.10.1
 
       - name: Publish package on TestPyPI
         if: (!steps.check-version.outputs.tag)
-        uses: pypa/gh-action-pypi-publish@v1.9.0
+        uses: pypa/gh-action-pypi-publish@v1.10.1
         with:
           repository-url: https://test.pypi.org/legacy/
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{"{{"}} matrix.python {{"}}"}}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{"{{"}} matrix.python {{"}}"}}
 {% raw %}
@@ -105,6 +105,7 @@ jobs:
         with:
           name: coverage-data-${{"{{"}} matrix.os {{"}}"}}-${{"{{"}} matrix.python {{"}}"}}
           path: ".coverage.*"
+          include-hidden-files: true
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
@@ -123,7 +124,7 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
 {% raw %}
@@ -173,4 +174,4 @@ jobs:
           SONAR_TOKEN: {{ "${{ secrets.SONAR_TOKEN }}" }}
         # No need to run SonarCloud analysis if dependabot update or token not defined
         if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
-        uses: SonarSource/sonarcloud-github-action@v2.3.0
+        uses: SonarSource/sonarcloud-github-action@v3.0.0

--- a/{{cookiecutter.project_name}}/tests/test_main.py
+++ b/{{cookiecutter.project_name}}/tests/test_main.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from {{cookiecutter.package_name}} import __main__
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner() -> CliRunner:
     """Fixture for invoking command-line interfaces."""
     return CliRunner()


### PR DESCRIPTION
From September 2nd, 2024, the GitHub action update-artifact does not upload hidden files and folders by default. This caused trouble with .coverage files, used by the template. This PR fixes this issue and updates dependencies.

Further description in issue https://github.com/actions/upload-artifact/issues/602 