### PR TITLE
Add support for poetry 2.x

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -3,6 +3,6 @@ cookiecutter==2.6.0
 cutty==0.18.0
 nox==2024.10.9
 nox-poetry==1.0.3
-poetry==1.8.4
+poetry==2.0.1
 pre-commit==4.0.1
-virtualenv==20.28.0
+virtualenv==20.28.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt nox nox-poetry
           pipx install --pip-args=--constraint=${{ github.workspace }}/ssb-pypitemplate/.github/workflows/constraints.txt poetry
+          pipx inject poetry poetry-plugin-export
       - name: Generate project using Cookiecutter
         run: |
           cookiecutter --no-input ssb-pypitemplate project_name=ssb-library

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,6 +19,7 @@ Install [Poetry]:
 
 ```console
 pipx install poetry
+pipx inject poetry poetry-plugin-export
 ```
 
 Install [Nox] and [nox-poetry]:

--- a/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
+++ b/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==24.3.1
 nox==2024.10.9
 nox-poetry==1.0.3
-poetry==1.8.4
-virtualenv==20.28.0
+poetry==2.0.1
+virtualenv==20.28.1

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 {% endraw %}
 

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 {% raw %}
       - name: Install Poetry
         run: |
-          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           pipx inject poetry poetry-plugin-export
           poetry --version
 {% endraw %}

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install Poetry
         run: |
           pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 {% endraw %}
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 {% endraw %}
 {% raw %}
@@ -137,6 +138,7 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 {% endraw %}
 {% raw %}


### PR DESCRIPTION
Add support for [poetry 2.x](https://python-poetry.org/blog/announcing-poetry-2.0.0/).

In poetry 2.x the poetry-plugin-export needed by `nox` is no longer installed by default, so install it explicitly.
If you run `nox` locally you need to run this command to add it to your local poetry environment:
`pipx inject poetry poetry-plugin-export`