### PR TITLE
Update to new SonarQube Cloud GitHub Action

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -119,7 +119,7 @@ use [pyenv] for installing and managing Python versions.
 Please refer to the documentation of this project
 for detailed installation and usage instructions.
 (The following instructions assume that
-your system already has [bash] and [curl] installed.)
+your system already has bash and [curl] installed.)
 
 Install [pyenv] like this:
 
@@ -2586,7 +2586,6 @@ You can also read the articles on [this blog][hypermodern python blog].
 [autodoc]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 [bandit codes]: https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
 [bandit]: https://github.com/PyCQA/bandit
-[bash]: https://www.gnu.org/software/bash/
 [batchelder include]: https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html
 [black]: https://github.com/psf/black
 [calendar versioning]: https://calver.org

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -167,13 +167,12 @@ jobs:
       # Replace root path with /github/workspace (mounted in docker container).
       - name: Override coverage source paths for SonarCloud
         run: |
-          sed -i "s/<source><\/source>/<source>\/github\/workspace<\/source>/g" coverage.xml
-          sed -i "s/<source>tests/<source>\/github\/workspace\/tests/g" coverage.xml
+          sed -i "s/<source><\/source>/<source>\/home\/runner\/work\/{{cookiecutter.project_name}}\/{{cookiecutter.project_name}}<\/source>/g" coverage.xml
+          sed -i "s/<source>tests/<source>\/home\/runner\/work\/{{cookiecutter.project_name}}\/{{cookiecutter.project_name}}\/tests/g" coverage.xml
 
-      - name: SonarCloud Scan
+      - name: SonarQube Cloud Scan
         env:
-          GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }} # Needed to get PR information, if any
           SONAR_TOKEN: {{ "${{ secrets.SONAR_TOKEN }}" }}
         # No need to run SonarCloud analysis if dependabot update or token not defined
         if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
-        uses: SonarSource/sonarcloud-github-action@v3.1.0
+        uses: SonarSource/sonarqube-scan-action@v4.1.0

--- a/{{cookiecutter.project_name}}/sonar-project.properties
+++ b/{{cookiecutter.project_name}}/sonar-project.properties
@@ -2,8 +2,8 @@ sonar.projectKey={{cookiecutter.github_organization}}_{{cookiecutter.project_nam
 sonar.organization={{cookiecutter.github_organization}}
 sonar.host.url=https://sonarcloud.io
 
-sonar.sources=src/{{cookiecutter.package_name}}
-sonar.tests=tests
+sonar.sources=src/{{cookiecutter.package_name}}/
+sonar.tests=tests/
 
 sonar.python.version=3.10
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
SonarCloud has been rebranded to SonarQube Cloud and there is now a new GitHub Action that is the official entrypoint for both SonarQube Server and SonarQube Cloud. See https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.1.0
