### PR TITLE
Release 2025.2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in [Statistics Norway].
 Use [Cruft] to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.1.14
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
 ```
 
 Cruft downloads the template, and asks you a series of questions about project variables,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ Here is a detailed list of features for this Python template:
 
 The {{ SPT }} uses [Calendar Versioning] with a `YYYY.MM.DD` versioning scheme.
 
-The current stable release is [2025.1.14].
+The current stable release is [2025.2.19].
 
 (installation)=
 
@@ -213,10 +213,10 @@ pipx upgrade poetry
 
 Create a project from this template
 by pointing Cruft to its [GitHub repository][ssb pypi template].
-Use the `--checkout` option with the [current stable release][2025.1.14]:
+Use the `--checkout` option with the [current stable release][2025.2.19]:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.1.14
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
 ```
 
 Cruft downloads the template,
@@ -2576,7 +2576,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [.github/dependabot.yml]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 [.gitignore]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [.readthedocs.yml]: https://docs.readthedocs.io/en/stable/config-file/v2.html
-[2025.1.14]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2025.1.14
+[2025.2.19]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2025.2.19
 [__main__]: https://docs.python.org/3/library/__main__.html
 [abstract syntax tree]: https://docs.python.org/3/library/ast.html
 [actions/cache]: https://github.com/actions/cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ and adopted for use in [Statistics Norway].
 Use [Cruft](https://cruft.github.io/cruft/) to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.1.14
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
 ```
 
 To check if there are there are template updates and update your instance with

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,7 +38,7 @@ It is recommended to set up Python 3.11, 3.12 and 3.13 using [pyenv].
 Generate a Python project:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.1.14
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
 ```
 
 Cruft downloads the template and asks you a series of questions about project variables.


### PR DESCRIPTION
## Changes

* Update to new SonarQube Cloud GitHub Action (#85) @arneso-ssb

## :rocket: Features

* Set default python version to 3.11 and add support for python 3.13 (#88) @arneso-ssb

## :package: Dependencies

* Update dependencies (#87) @arneso-ssb
* Update GHA versions and ignore some more ruff rules (#86) @arneso-ssb
