### PR TITLE
Add deptry tool for listing unused or missed dependencies

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1992,6 +1992,12 @@ The following options are enabled for strictness and enhanced output:
 - {option}`show_column_numbers <mypy --show-column-numbers>`
 - {option}`show_error_context <mypy --show-error-context>`
 
+## Checking dependencies with deptry
+
+[deptry] is a command line tool to check for issues with dependencies in a Python project, such as unused or missing dependencies.
+
+Usage: `poetry run deptry .` from the root directory.
+
 (external-services)=
 
 ## External services
@@ -2610,6 +2616,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [dependabot docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 [dependabot issue 4435]: https://github.com/dependabot/dependabot-core/issues/4435
 [dependabot]: https://github.com/features/security/
+[deptry]: https://deptry.com/
 [dev-prod parity]: https://12factor.net/dev-prod-parity
 [editable install]: https://pip.pypa.io/en/stable/cli/pip_install/#install-editable
 [end-of-file-fixer]: https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -45,6 +45,7 @@ sphinx-click = ">=3.0.2"
 typeguard = ">=2.13.3"
 xdoctest = { extras = ["colors"], version = ">=0.15.10" }
 myst-parser = { version = ">=0.16.1" }
+deptry = ">=0.23.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.9"
@@ -70,6 +71,9 @@ fail_under = 50
 {% else %}
 fail_under = 20
 {% endif %}
+
+[tool.deptry.per_rule_ignores]
+DEP001 = ["nox", "nox_poetry"]  # packages available by default
 
 [tool.mypy]
 strict = true
@@ -116,7 +120,7 @@ select = [
 ]
 {% endif %}
 ignore = [
-    "ANN202", # Don't requiere return type annotation for private functions.
+    "ANN202", # Don't require return type annotation for private functions.
     "ANN401", # Allow type annotation with type Any.
     "D100",   # Supress undocumented-public-module. Only doc of public api required.
     "FBT001", # Allow boolean positional arguments in a function.


### PR DESCRIPTION
See description of deptry at the [deptry page](https://deptry.com/).
Usage: `poetry run deptry .` at the root directory.