### PR TITLE
Fix department file location

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,10 +36,12 @@ def set_department_name():
     if department_number and department_number.isdigit():
         # Use the directory containing this script as the template root
         template_dir = Path(__file__).parent.parent
-        department_file = template_dir / "hooks" / "statistics_norway_departments.csv"
+
+        # The department file is stored in a temp directory. Need to search for it.
+        department_file = next(template_dir.rglob("hooks/statistics_norway_departments.csv"), None)
 
         department_lookup = {}
-        if department_file.exists():
+        if department_file and department_file.exists():
             with department_file.open(encoding="utf-8") as csvfile:
                 reader = csv.DictReader(csvfile, delimiter=";")
                 for row in reader:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -34,10 +34,9 @@ def set_department_name():
     """
     department_number = "{{ cookiecutter.department_number }}"
     if department_number and department_number.isdigit():
-        template_dir = r"{{ cookiecutter._template }}"  # path to the template root dir
-        department_file = (
-            Path(template_dir).resolve() / "hooks" / "statistics_norway_departments.csv"
-        )
+        # Use the directory containing this script as the template root
+        template_dir = Path(__file__).parent.parent
+        department_file = template_dir / "hooks" / "statistics_norway_departments.csv"
 
         department_lookup = {}
         if department_file.exists():

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -30,12 +30,14 @@ def validate_department_number():
         sys.exit(1)
 
     # Read the CSV file and create a lookup table
-    template_dir = r"{{ cookiecutter._template }}"  # path to the template root dir
-    department_file = (
-        Path(template_dir).resolve() / "hooks" / "statistics_norway_departments.csv"
-    )
+    # Use the directory containing this script as the template root
+    template_dir = Path(__file__).parent.parent
+
+    # The departments file is stored in a temp directory. Need to search for it.
+    department_file = next(template_dir.rglob("hooks/statistics_norway_departments.csv"), None)
+
     department_lookup = {}
-    if department_file.exists():
+    if department_file and department_file.exists():
         with department_file.open(encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile, delimiter=";")
             for row in reader:
@@ -43,7 +45,7 @@ def validate_department_number():
                 if row["level"] == "2":
                     department_lookup[row["code"]] = row["name"].rstrip()
     else:
-        print(f"Error: Department file '{department_file}' not found.")
+        print(f"vdm Error: Department file '{department_file}' not found.")
         sys.exit(1)
 
     # Validate that the department number exists in the lookup table and print the list

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -33,7 +33,7 @@ def validate_department_number():
     # Use the directory containing this script as the template root
     template_dir = Path(__file__).parent.parent
 
-    # The departments file is stored in a temp directory. Need to search for it.
+    # The department file is stored in a temp directory. Need to search for it.
     department_file = next(template_dir.rglob("hooks/statistics_norway_departments.csv"), None)
 
     department_lookup = {}
@@ -45,7 +45,7 @@ def validate_department_number():
                 if row["level"] == "2":
                     department_lookup[row["code"]] = row["name"].rstrip()
     else:
-        print(f"vdm Error: Department file '{department_file}' not found.")
+        print(f"Error: Department file '{department_file}' not found.")
         sys.exit(1)
 
     # Validate that the department number exists in the lookup table and print the list

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -20,7 +20,6 @@ parts/
 sdist/
 var/
 wheels/
-pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
@@ -47,9 +46,10 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -72,6 +72,7 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook
@@ -103,6 +104,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -128,12 +130,20 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
 # PyCharm
 .idea/
 
-/.python-version
-/.pytype/
-/docs/_build/
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
 
 # Visual Studio Code
 .vscode/*
@@ -146,3 +156,22 @@ dmypy.json
 .history/
 # Built Visual Studio Code Extensions
 *.vsix
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+# Other
+/docs/_build/
+*.rej
+*.orig


### PR DESCRIPTION
When the project is generated from a url, the `{{ cookiecutter._template }}` is not a base directory, but a url and cannot be used as a directory. The template repo files are stored in a random temp directory and need to be searched for. This commit fixes this.

In addition the `.gitignore` is updated with relevant changes from the GitHub python template and the Statistics Norway template.
