### PR TITLE
Add support for uv as an alternative dependency manager

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,10 +19,11 @@
     "Development Status :: 7 - Inactive"
   ],
   "code_quality_level": ["Medium", "High", "Low"],
+  "dependency_manager_tool": ["poetry", "uv"],
   "department_number": "",
   "_copy_without_render": ["*.rst_t"],
   "_jinja2_env_vars": { "lstrip_blocks": true, "trim_blocks": true },
   "__prompts__": {
-    "department_number": "Maintainer: Statistics Norway department number (press enter if not in Statistics Norway)"
+    "department_number": "Maintainer: Statistics Norway department/'seksjon' number (press enter if not in Statistics Norway)"
   }
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -174,9 +174,14 @@ use [pip install] with the `--user` option instead.
 You need four tools to use this template:
 
 - [Cruft] to create projects from the template,
-- [Poetry] to manage packaging and dependencies
+- [Poetry] or [uv] to manage packaging and dependencies
 - [Nox] to automate checks and other tasks
 - [nox-poetry] for using Poetry in Nox sessions
+
+When you create a project you are asked if you want to use `poetry` or `uv` as
+a dependency manager tool. You only need one of these. There is no need to install
+`uv` if you only use `poetry`, and no need to install `poetry` and `nox-poetry`
+if you only use `uv`.
 
 Install [Cruft] using pipx:
 
@@ -184,17 +189,18 @@ Install [Cruft] using pipx:
 pipx install cruft[pyproject]
 ```
 
-Install [Poetry] using pipx:
+Install [Poetry] or [uv] using pipx:
 
 ```console
-pipx install poetry
+pipx install poetry  # If selecting poetry as a dependency manager
+pipx install uv      # If selecting uv as a dependency manager
 ```
 
 Install [Nox] and [nox-poetry] using pipx:
 
 ```console
 pipx install nox
-pipx inject nox nox-poetry
+pipx inject nox nox-poetry  # Only if you use poetry as a dependency manager tool
 ```
 
 Remember to upgrade these tools regularly:
@@ -203,6 +209,7 @@ Remember to upgrade these tools regularly:
 pipx upgrade cruft
 pipx upgrade --include-injected nox
 pipx upgrade poetry
+pipx upgrade uv
 ```
 
 ## Project creation
@@ -271,6 +278,12 @@ Here is a complete list of the project variables defined by this template:
 - - `code_quality_level`
   - Requirements for code quality level
   - `Medium`
+- - `dependency_manager_tool`
+  - Select between `poetry` and `uv`
+  - `poetry`
+- - `department_number`
+  - Statistics Norway only: Department/"seksjon" number responsible for maintaining the library
+  - `703`
 
 :::
 
@@ -2747,6 +2760,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [type annotations]: https://docs.python.org/3/library/typing.html
 [typeguard]: https://github.com/agronholm/typeguard
 [unix-style line endings]: https://en.wikipedia.org/wiki/Newline
+[uv]: https://docs.astral.sh/uv/
 [versions and constraints]: https://python-poetry.org/docs/dependency-specification/
 [virtual environment]: https://docs.python.org/3/tutorial/venv.html
 [virtualenv]: https://virtualenv.pypa.io/

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,9 @@
 
 ## Requirements
 
+When you create a project, you are asked if you want to use [poetry] or [uv] as a
+dependency manager tool. You only need to install one of them.
+
 Install [pipx]:
 
 ```console
@@ -15,18 +18,24 @@ Install [cruft]:
 pipx install cruft[pyproject]
 ```
 
-Install [Poetry]:
+Install [Nox]:
+
+```console
+pipx install nox
+```
+
+Install [Poetry] and [nox-poetry]:
 
 ```console
 pipx install poetry
 pipx inject poetry poetry-plugin-export
+pipx inject nox nox-poetry
 ```
 
-Install [Nox] and [nox-poetry]:
+Install [uv]:
 
 ```console
-pipx install nox
-pipx inject nox nox-poetry
+pipx install uv
 ```
 
 [pipx] is preferred, but you can also install with `pip install --user`.
@@ -53,12 +62,24 @@ git add .
 git commit
 ```
 
-## Installing the environment
+### Install the environment and create a lock-file
 
 Install the virtual environment using the command:
 
+If using [poetry]:
+
 ```console
 poetry update
+git add poetry.lock
+git commit
+```
+
+If using [uv]:
+
+```console
+uv sync
+git add uv.lock
+git commit
 ```
 
 ## Testing
@@ -198,3 +219,4 @@ by applying labels to them, like this:
 [sonarcloud]: https://www.sonarsource.com/products/sonarcloud/
 [testpypi]: https://test.pypi.org/
 [trusted publisher]: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
+[uv]: https://docs.astral.sh/uv/

--- a/{{cookiecutter.project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_name}}/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       workflows-dependencies:
         patterns:
           - "*"
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -30,3 +31,14 @@ updates:
       poetry-dependencies:
         patterns:
           - "*"
+{% else %}
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 99
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+{% endif %}

--- a/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
+++ b/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
@@ -1,5 +1,8 @@
-pip==25.1.1
 nox==2025.5.1
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
+pip==25.1.1
 nox-poetry==1.2.0
 poetry==2.1.3
-virtualenv==20.31.2
+{% else %}
+uv==0.8.0
+{% endif %}

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -27,27 +27,50 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-{% raw %}
+
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" poetry
           pipx inject poetry poetry-plugin-export
           poetry --version
-{% endraw %}
 
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.12"
           cache: "poetry"
+{% else %}
+      - name: Get uv version from constraints
+        id: uv-version
+        shell: pwsh
+        run: |
+          $UV_VERSION = (Get-Content .github/workflows/constraints.txt | Where-Object { $_ -match '^uv==' } | ForEach-Object { ($_ -split '==')[1] })
+          echo "version=$UV_VERSION" >> $env:GITHUB_OUTPUT
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          version: {{ "${{ steps.uv-version.outputs.version }}" }}
+          python-version: "3.12"
+{% endif %}
 
       - name: Install dependencies
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           poetry install
+{% else %}
+          uv sync --locked --only-dev
+{% endif %}
 
       - name: Build doc with Sphinx
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           poetry run sphinx-build docs docs/_build
+{% else %}
+          uv run sphinx-build docs docs/_build
+{% endif %}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -20,23 +20,37 @@ jobs:
         with:
           fetch-depth: 2
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.12"
-{% raw %}
+
       - name: Upgrade pip
         run: |
-          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install -c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt pip
           pip --version
-{% endraw %}
-{% raw %}
+
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" poetry
           pipx inject poetry poetry-plugin-export
           poetry --version
-{% endraw %}
+{% else %}
+      - name: Get uv version from constraints
+        id: uv-version
+        shell: pwsh
+        run: |
+          $UV_VERSION = (Get-Content .github/workflows/constraints.txt | Where-Object { $_ -match '^uv==' } | ForEach-Object { ($_ -split '==')[1] })
+          echo "version=$UV_VERSION" >> $env:GITHUB_OUTPUT
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          version: {{ "${{ steps.uv-version.outputs.version }}" }}
+          python-version: "3.12"
+{% endif %}
 
       - name: Check if there is a parent commit
         id: check-parent-commit
@@ -49,18 +63,32 @@ jobs:
         uses: salsify/action-detect-and-tag-new-version@v2.0.3
         with:
           version-command: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
             bash -o pipefail -c "poetry version | cut -f 2 -d' '"
+{% else %}
+            uv version --short
+{% endif %}
 
       - name: Bump version for developmental release
         if: (!steps.check-version.outputs.tag)
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           poetry version patch &&
           version=$(poetry version | awk '{ print $2 }') &&
           poetry version $version.dev.$(date +%s)
+{% else %}
+          uv version --bump patch --frozen &&
+          version=$(uv version --short) &&
+          uv version $version.dev.$(date +%s) --no-sync
+{% endif %}
 
       - name: Build package
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           poetry build --ansi
+{% else %}
+          uv build
+{% endif %}
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -41,16 +41,16 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
       - name: Set up Python ${{"{{"}} matrix.python {{"}}"}}
         uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{"{{"}} matrix.python {{"}}"}}
-{% raw %}
+
       - name: Upgrade pip
         run: |
-          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install -c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt pip
           pip --version
-{% endraw %}
 
       - name: Upgrade pip in virtual environments
         shell: python
@@ -60,20 +60,33 @@ jobs:
 
           with open(os.environ["GITHUB_ENV"], mode="a") as io:
               print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
-{% raw %}
+
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" poetry
           pipx inject poetry poetry-plugin-export
           poetry --version
-{% endraw %}
-{% raw %}
+
       - name: Install Nox
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
-          pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
-{% endraw %}
+{% else %}
+      - name: Get uv version from constraints
+        id: uv-version
+        shell: pwsh
+        run: |
+          $UV_VERSION = (Get-Content .github/workflows/constraints.txt | Where-Object { $_ -match '^uv==' } | ForEach-Object { ($_ -split '==')[1] })
+          echo "version=$UV_VERSION" >> $env:GITHUB_OUTPUT
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          version: {{ "${{ steps.uv-version.outputs.version }}" }}
+          python-version: ${{"{{"}} matrix.python {{"}}"}}
+{% endif %}
 
       - name: Compute pre-commit cache key
         if: matrix.session == 'pre-commit'
@@ -102,7 +115,11 @@ jobs:
 
       - name: Run Nox
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           nox --python=${{"{{"}} matrix.python {{"}}"}}
+{% else %}
+          uvx --constraints "${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox --python=${{ "{{ matrix.python }}" }}
+{% endif %}
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
@@ -128,30 +145,43 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.11"
-{% raw %}
+
       - name: Upgrade pip
         run: |
-          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip install -c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt pip
           pip --version
-{% endraw %}
-{% raw %}
+
       - name: Install Poetry
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" poetry
           pipx inject poetry poetry-plugin-export
           poetry --version
-{% endraw %}
-{% raw %}
+
       - name: Install Nox
         run: |
-          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
-          pipx inject --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
+          pipx install --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args "-c ${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
-{% endraw %}
+{% else %}
+      - name: Get uv version from constraints
+        id: uv-version
+        shell: pwsh
+        run: |
+          $UV_VERSION = (Get-Content .github/workflows/constraints.txt | Where-Object { $_ -match '^uv==' } | ForEach-Object { ($_ -split '==')[1] })
+          echo "version=$UV_VERSION" >> $env:GITHUB_OUTPUT
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          version: {{ "${{ steps.uv-version.outputs.version }}" }}
+          python-version: "3.11"
+{% endif %}
 
       - name: Download coverage data
         uses: actions/download-artifact@v4
@@ -161,11 +191,19 @@ jobs:
 
       - name: Combine coverage data and display human readable report
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           nox --session=coverage
+{% else %}
+          uvx --constraints "${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox --session=coverage
+{% endif %}
 
       - name: Create coverage report
         run: |
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
           nox --session=coverage -- xml
+{% else %}
+          uvx --constraints "${{ "{{ github.workspace }}" }}/.github/workflows/constraints.txt" nox --session=coverage -- xml
+{% endif %}
 
       # Need to fix coverage source paths for SonarCloud scanning in GitHub actions.
       # Replace root path with /github/workspace (mounted in docker container).

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -18,7 +18,6 @@
 [pypi status]: https://pypi.org/project/{{cookiecutter.project_name}}/
 [documentation]: https://{{cookiecutter.github_organization}}.github.io/{{cookiecutter.project_name}}
 [tests]: https://github.com/{{cookiecutter.github_organization}}/{{cookiecutter.project_name}}/actions?workflow=Tests
-
 [sonarcov]: https://sonarcloud.io/summary/overall?id={{cookiecutter.github_organization}}_{{cookiecutter.project_name}}
 [sonarquality]: https://sonarcloud.io/summary/overall?id={{cookiecutter.github_organization}}_{{cookiecutter.project_name}}
 [pre-commit]: https://github.com/pre-commit/pre-commit

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import nox
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
 
 
 try:
@@ -21,6 +22,10 @@ except ImportError:
 
     {sys.executable} -m pip install nox-poetry"""
     raise SystemExit(dedent(message)) from None
+{% else %}
+from nox import Session
+
+{% endif %}
 
 package = "{{cookiecutter.package_name}}"
 python_versions = ["3.11", "3.12", "3.13"]
@@ -34,6 +39,33 @@ nox.options.sessions = (
     "xdoctest",
     "docs-build",
 )
+{% if cookiecutter.dependency_manager_tool == "uv" %}
+nox.options.default_venv_backend = "uv"
+session = nox.session
+
+
+def install_with_uv(
+    session: Session,
+    *,
+    only_dev: bool = False,
+    all_extras: bool = False,
+    locked: bool = True,
+) -> None:
+    """Install packages using uv, pinned to uv.lock."""
+    cmd = ["uv", "sync"]
+    if locked:
+        cmd.append("--locked")
+    if only_dev:
+        cmd.append("--only-dev")
+    if all_extras:
+        cmd.append("--all-extras")
+    cmd.append(
+        f"--python={session.virtualenv.location}"
+    )  # Target the nox venv's Python interpreter
+    session.run_install(
+        *cmd, env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+    )
+{% endif %}
 
 
 def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
@@ -128,6 +160,7 @@ def precommit(session: Session) -> None:
         "--hook-stage=manual",
         "--show-diff-on-failure",
     ]
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(
         "pre-commit",
         "pre-commit-hooks",
@@ -135,6 +168,9 @@ def precommit(session: Session) -> None:
         "ruff",
         "black",
     )
+{% else %}
+    install_with_uv(session, only_dev=True)
+{% endif %}
     session.run("pre-commit", *args)
     if args and args[0] == "install":
         activate_virtualenv_in_precommit_hooks(session)
@@ -144,8 +180,12 @@ def precommit(session: Session) -> None:
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests"]
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install("mypy", "pytest")
+{% else %}
+    install_with_uv(session)
+{% endif %}
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
@@ -154,8 +194,12 @@ def mypy(session: Session) -> None:
 @session(python=python_versions_for_test)
 def tests(session: Session) -> None:
     """Run the test suite."""
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install("coverage[toml]", "pytest", "pygments")
+{% else %}
+    install_with_uv(session)
+{% endif %}
     try:
         session.run(
             "coverage",
@@ -177,7 +221,11 @@ def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report", "--skip-empty"]
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install("coverage[toml]")
+{% else %}
+    install_with_uv(session)
+{% endif %}
 
     if not session.posargs and any(Path().glob(".coverage.*")):
         session.run("coverage", "combine")
@@ -188,8 +236,12 @@ def coverage(session: Session) -> None:
 @session(python=python_versions[0])
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install("pytest", "typeguard", "pygments")
+{% else %}
+    install_with_uv(session)
+{% endif %}
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
@@ -203,8 +255,12 @@ def xdoctest(session: Session) -> None:
         if "FORCE_COLOR" in os.environ:
             args.append("--colored=1")
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install("xdoctest[colors]")
+{% else %}
+    install_with_uv(session)
+{% endif %}
     session.run("python", "-m", "xdoctest", *args)
 
 
@@ -215,10 +271,14 @@ def docs_build(session: Session) -> None:
     if not session.posargs and "FORCE_COLOR" in os.environ:
         args.insert(0, "--color")
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install(
         "sphinx", "sphinx-autodoc-typehints", "sphinx-click", "furo", "myst-parser"
     )
+{% else %}
+    install_with_uv(session, only_dev=True)
+{% endif %}
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -231,6 +291,7 @@ def docs_build(session: Session) -> None:
 def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
     session.install(".")
     session.install(
         "sphinx",
@@ -240,6 +301,9 @@ def docs(session: Session) -> None:
         "furo",
         "myst-parser",
     )
+{% else %}
+    install_with_uv(session, only_dev=True)
+{% endif %}
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -2,17 +2,30 @@
 name = "{{cookiecutter.project_name}}"
 version = "{{cookiecutter.version}}"
 description = "{{cookiecutter.friendly_name}}"
-authors = [{name = "{{cookiecutter.author}}", email = "{{cookiecutter.email}}"}]
+authors = [{ name = "{{cookiecutter.author}}", email = "{{cookiecutter.email}}" }]
+{% if cookiecutter.department_number is defined and cookiecutter.department_number %}
+maintainers = [{ name = "__DEPARTMENT_NAME__" }]
+{% endif %}
 license = "{{cookiecutter.license}}"
 readme = "README.md"
-dynamic = ["classifiers"]
 requires-python = ">=3.10,<4.0"
-dependencies = [
-    "click (>=8.0.1)"
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
+dynamic = ["classifiers"]
+{% else %}
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "License :: OSI Approved :: MIT License",
+  "Development Status :: 4 - Beta",
+  "Typing :: Typed",
 ]
-{% if cookiecutter.department_number is defined and cookiecutter.department_number %}
-maintainers = [{name = "__DEPARTMENT_NAME__"}]
 {% endif %}
+dependencies = [
+    "click>=8.0.1",
+]
 
 [project.urls]
 homepage = "https://github.com/{{cookiecutter.github_organization}}/{{cookiecutter.project_name}}"
@@ -23,6 +36,7 @@ Changelog = "https://github.com/{{cookiecutter.github_organization}}/{{cookiecut
 [project.scripts]
 {{cookiecutter.project_name}} = "{{cookiecutter.package_name}}.__main__:main"
 
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
 [tool.poetry]
 classifiers = ["{{cookiecutter.development_status}}"]
 requires-poetry = ">=2.0"
@@ -52,6 +66,29 @@ deptry = ">=0.23.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.9"
+{% else %}
+[dependency-groups]
+dev = [
+    "pygments>=2.10.0",
+    "black[jupyter]>=23.1.0",
+    "coverage[toml]>=6.2",
+    "darglint>=1.8.1",
+    "furo>=2021.11.12",
+    "mypy>=0.930",
+    "pre-commit>=2.16.0",
+    "pre-commit-hooks>=4.1.0",
+    "ruff>=0.0.284",
+    "pytest>=6.2.5",
+    "sphinx>=6.2.1",
+    "sphinx-autobuild>=2021.3.14",
+    "sphinx-autodoc-typehints>=1.24.0",
+    "sphinx-click>=3.0.2",
+    "typeguard>=2.13.3",
+    "xdoctest[colors]>=0.15.10",
+    "myst-parser>=0.16.1",
+    "deptry>=0.23.0",
+]
+{% endif %}
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
@@ -76,7 +113,11 @@ fail_under = 20
 {% endif %}
 
 [tool.deptry.per_rule_ignores]
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
 DEP001 = ["nox", "nox_poetry"]  # packages available by default
+{% else %}
+DEP001 = ["nox"]  # packages available by default
+{% endif %}
 
 [tool.mypy]
 strict = true
@@ -165,6 +206,16 @@ classmethod-decorators = ["classmethod", "validator", "root_validator", "pydanti
     "S101",    # asserts are encouraged in pytest
 ]
 
+{% if cookiecutter.dependency_manager_tool == "uv" and cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') %}
+[tool.uv.build-backend]
+module-name = "{{cookiecutter.package_name}}"
+
+{% endif %}
 [build-system]
+{% if cookiecutter.dependency_manager_tool == "poetry" %}
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+{% else %}
+requires = ["uv_build>=0.8.0,<0.9"]
+build-backend = "uv_build"
+{% endif %}


### PR DESCRIPTION
This pull request introduces support for [uv](https://docs.astral.sh/uv/) as an alternative dependency manager tool alongside the existing [poetry](https://python-poetry.org/docs/) support. Poetry is still the default.

The user can select between using [poetry](https://python-poetry.org/docs/) and [uv](https://docs.astral.sh/uv/)  when creating a new project.
