### PR TITLE
Release 2025.7.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in [Statistics Norway].
 Use [Cruft] to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.7.18
 ```
 
 Cruft downloads the template, and asks you a series of questions about project variables,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ Here is a detailed list of features for this Python template:
 
 The {{ SPT }} uses [Calendar Versioning] with a `YYYY.MM.DD` versioning scheme.
 
-The current stable release is [2025.2.19].
+The current stable release is [2025.7.18].
 
 (installation)=
 
@@ -220,10 +220,10 @@ pipx upgrade uv
 
 Create a project from this template
 by pointing Cruft to its [GitHub repository][ssb pypi template].
-Use the `--checkout` option with the [current stable release][2025.2.19]:
+Use the `--checkout` option with the [current stable release][2025.7.18]:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.7.18
 ```
 
 Cruft downloads the template,
@@ -2595,7 +2595,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [.github/dependabot.yml]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 [.gitignore]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [.readthedocs.yml]: https://docs.readthedocs.io/en/stable/config-file/v2.html
-[2025.2.19]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2025.2.19
+[2025.7.18]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2025.7.18
 [__main__]: https://docs.python.org/3/library/__main__.html
 [abstract syntax tree]: https://docs.python.org/3/library/ast.html
 [actions/cache]: https://github.com/actions/cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ and adopted for use in [Statistics Norway].
 Use [Cruft](https://cruft.github.io/cruft/) to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.7.18
 ```
 
 To check if there are there are template updates and update your instance with

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,7 @@ It is recommended to set up Python 3.11, 3.12 and 3.13 using [pyenv].
 Generate a Python project:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.2.19
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2025.7.18
 ```
 
 Cruft downloads the template and asks you a series of questions about project variables.


### PR DESCRIPTION
## Changes

## :rocket: Features

* Add support for [uv](https://docs.astral.sh/uv/) as an alternative dependency manager (#96) @arneso-ssb
* Add maintainer info to the template (#94) @arneso-ssb
* Add deptry tool for listing unused or missing dependencies (#93) @arneso-ssb

## :beetle: Fixes

* Fix department file location (#95) @arneso-ssb

## :package: Dependencies

* Fix GitHub action permission and update GitHub action dependencies (#92) @arneso-ssb
* Make pyproject.toml PEP 631 compatible (#91) @arneso-ssb

## :book: Update instructions

This is a rather large update and there are two new questions when creating a project, which are described in the [creating a project](https://statisticsnorway.github.io/ssb-pypitemplate/guide.html#creating-a-project) section in the user guide. Some extra update instructions are needed.

This release adds a new variable to cruft: department_number("seksjonsnummer"), with an empty default value. In order to set it and make the code automatically look up the department name and insert it into `pyproject.toml`, do this:

For Statistics Norway repos only:

1. Update your repo the normal way with the command `cruft update --checkout=2025.7.18` on a new branch. Follow the instructions on the [help page](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/4111400971/Hvordan+oppdatere+GitHub-repo+med+oppdateringer+fra+underliggende+mal).
2. Commit your changes and make sure that `git status` is clean.
3. Update the repo with the department number ("seksjonsnummer") which is responsible for maintaining the repo. Do this by running the following command, but replace the department_number with the correct one: `cruft update --variables-to-update '{ "department_number" : "703" }'` (on linux). If you are running the the command on Windows you need this command instead: `cruft update --variables-to-update '{ ""department_number"" : ""703"" }'`
4. Run `poetry update` and commit your changes.
5. Git push, make a pull request and merge.

Poetry is still the default dependency manager, but if you want to try `uv` on your existing repo you can look at the [uv-branch on the ssb-pypitemplate-instance repo](https://github.com/statisticsnorway/ssb-pypitemplate-instance/tree/uv) and compare it with the main-branch, which is poetry-based.