### PR TITLE
Remove support for python 3.10 and 3.11, 3.13 now default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - { python-version: "3.13", os: windows-latest }
           - { python-version: "3.13", os: macos-latest }
           - { python-version: "3.12", os: ubuntu-latest }
-          - { python-version: "3.11", os: ubuntu-latest }
+          - { python-version: "3.14", os: ubuntu-latest }
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cruft update
 - Generate command-line reference with [sphinx-click]
 - Manage project labels with [GitHub Labeler]
 
-The template supports Python 3.10, 3.10 and 3.12.
+The template supports Python 3.12, 3.13 and 3.14.
 
 [autodoc]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 [black]: https://github.com/psf/black

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -100,15 +100,15 @@ python -VV
 py -VV
 ```
 
-Both of these commands should display the latest Python version, 3.13.
+Both of these commands should display the latest Python version, 3.14.
 
 For local testing with multiple Python versions,
-repeat these steps for the latest bugfix releases of Python 3.10+,
+repeat these steps for the latest bugfix releases of Python 3.12+,
 with the following changes:
 
 - Do _not_ enable the option to add Python to the `PATH` environment variable.
 - `py -VV` and `python -VV` should still display the version of the latest stable release.
-- `py -X.Y -VV` (e.g. `py -3.12 -VV`) should display the exact version you just installed.
+- `py -X.Y -VV` (e.g. `py -3.13 -VV`) should display the exact version you just installed.
 
 Note that binary installers are not provided for security releases.
 
@@ -139,13 +139,12 @@ Install the Python build dependencies for your platform,
 using one of the commands listed in the [official instructions][pyenv wiki].
 
 Install the latest point release of every supported Python version.
-This project template supports Python 3.10, 3.11, 3.12 and 3.13.
+This project template supports Python 3.12, 3.13 and 3.14.
 
 ```console
-pyenv install 3.10.16
-pyenv install 3.11.11
-pyenv install 3.12.9
-pyenv install 3.13.2
+pyenv install 3.12.12
+pyenv install 3.13.12
+pyenv install 3.14.3
 ```
 
 After creating your project (see [below](creating-a-project)),
@@ -153,12 +152,12 @@ you can make these Python versions accessible in the project directory,
 using the following command:
 
 ```console
-pyenv local 3.11.6 3.10.13 3.12.2
+pyenv local 3.12.12 3.13.12 3.14.3
 ```
 
 The first version listed is the one used when you type plain `python`.
 Every version can be used by invoking `python<major.minor>`.
-For example, use `python3.10` to invoke Python 3.10.
+For example, use `python3.12` to invoke Python 3.12.
 
 ### Requirements
 
@@ -992,13 +991,13 @@ for every Python version supported by your project,
 and easily switch between them:
 
 ```console
-poetry env use 3.10
-poetry env use 3.11
 poetry env use 3.12
+poetry env use 3.13
+poetry env use 3.14
 ```
 
 Only one Poetry environment can be active at any time.
-Note that `3.12` comes last,
+Note that `3.14` comes last,
 to ensure that the current Python release is the active environment.
 Install your package with `poetry install` into each environment after creating it.
 
@@ -1197,35 +1196,35 @@ The following table gives an overview of the available Nox sessions:
   - Default
 - - [coverage](the-coverage-session)
   - Report coverage with [Coverage.py]
-  - `3.10`
+  - `3.13`
   - (✓)
 - - [docs](the-docs-session)
   - Build and serve [Sphinx] documentation
-  - `3.10`
+  - `3.13`
   -
 - - [docs-build](the-docs-build-session)
   - Build [Sphinx] documentation
-  - `3.10`
+  - `3.13`
   - ✓
 - - [mypy](the-mypy-session)
   - Type-check with [mypy]
-  - `3.10` … `3.12`
+  - `3.12` … `3.14`
   - ✓
 - - [pre-commit](the-pre-commit-session)
   - Lint with [pre-commit]
-  - `3.10`
+  - `3.13`
   - ✓
 - - [tests](the-tests-session)
   - Run tests with [pytest]
-  - `3.10` … `3.12`
+  - `3.12` … `3.14`
   - ✓
 - - [typeguard](the-typeguard-session)
   - Type-check with [Typeguard]
-  - `3.10`
+  - `3.13`
   - ✓
 - - [xdoctest](the-xdoctest-session)
   - Run examples with [xdoctest]
-  - `3.10` … `3.12`
+  - `3.12` … `3.14`
   - ✓
 
 :::

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,7 +40,7 @@ pipx install uv
 
 [pipx] is preferred, but you can also install with `pip install --user`.
 
-It is recommended to set up Python 3.11, 3.12 and 3.13 using [pyenv].
+It is recommended to set up Python 3.12, 3.13 and 3.14 using [pyenv].
 
 ## Creating a project
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 furo==2025.12.19
-myst-parser==4.0.1
-sphinx==8.2.3
+myst-parser==5.0.0
+sphinx==9.1.0
 sphinx-autobuild==2025.8.25
 sphinx-copybutton==0.5.2

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "poetry"
 {% else %}
       - name: Get uv version from constraints
@@ -53,7 +53,7 @@ jobs:
         with:
           enable-cache: true
           version: {{ "${{ steps.uv-version.outputs.version }}" }}
-          python-version: "3.12"
+          python-version: "3.13"
 {% endif %}
 
       - name: Install dependencies

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Upgrade pip
         run: |
@@ -49,7 +49,7 @@ jobs:
         with:
           enable-cache: true
           version: {{ "${{ steps.uv-version.outputs.version }}" }}
-          python-version: "3.12"
+          python-version: "3.13"
 {% endif %}
 
       - name: Check if there is a parent commit

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -18,19 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python: "3.11", os: "ubuntu-latest", session: "pre-commit" }
-          - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.13", os: "ubuntu-latest", session: "pre-commit" }
           - { python: "3.12", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.13", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.11", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.14", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.14", os: "ubuntu-latest", session: "tests" }
           - { python: "3.13", os: "windows-latest", session: "tests" }
           - { python: "3.13", os: "macos-latest", session: "tests" }
-          - { python: "3.11", os: "ubuntu-latest", session: "typeguard" }
-          - { python: "3.11", os: "ubuntu-latest", session: "xdoctest" }
-          - { python: "3.11", os: "ubuntu-latest", session: "docs-build" }
+          - { python: "3.13", os: "ubuntu-latest", session: "typeguard" }
+          - { python: "3.13", os: "ubuntu-latest", session: "xdoctest" }
+          - { python: "3.13", os: "ubuntu-latest", session: "docs-build" }
 
     env:
       NOXSESSION: ${{"{{"}} matrix.session {{"}}"}}
@@ -149,7 +148,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Upgrade pip
         run: |

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.13
 repos:
   - repo: local
     hooks:

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Request features on the [Issue Tracker].
 
 ## How to set up your development environment
 
-You need Python 3.10+ and the following tools:
+You need Python 3.12+ and the following tools:
 
 - [Poetry]
 - [Nox]

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -26,12 +26,11 @@ except ImportError:
     raise SystemExit(dedent(message)) from None
 {% else %}
 from nox import Session
-
 {% endif %}
 
 package = "{{cookiecutter.package_name}}"
-python_versions = ["3.11", "3.12", "3.13"]
-python_versions_for_test = python_versions + ["3.10"]
+python_versions = ["3.13", "3.12", "3.14"]
+python_versions_for_test = python_versions
 nox.needs_version = ">= 2025.2.9"
 nox.options.sessions = (
     "pre-commit",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,7 +8,7 @@ maintainers = [{ name = "__DEPARTMENT_NAME__" }]
 {% endif %}
 license = "{{cookiecutter.license}}"
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.12"
 {% if cookiecutter.dependency_manager_tool == "poetry" %}
 dynamic = ["classifiers"]
 {% else %}
@@ -47,12 +47,12 @@ lint = [
     "ruff>=0.14.5",
 ]
 doc = [
-    "furo>=2025.9.25; python_version >= '3.11'",
-    "myst-parser>=4.0.1; python_version >= '3.11'",
-    "sphinx>=8.2.3; python_version >= '3.11'",
-    "sphinx-autobuild>=2025.8.25; python_version >= '3.11'",
-    "sphinx-autodoc-typehints>=3.5.2; python_version >= '3.11'",
-    "sphinx-click>=6.1.0; python_version >= '3.11'",
+    "furo>=2025.9.25",
+    "myst-parser>=4.0.1",
+    "sphinx>=8.2.3",
+    "sphinx-autobuild>=2025.8.25",
+    "sphinx-autodoc-typehints>=3.5.2",
+    "sphinx-click>=6.1.0",
 ]
 
 # Type hint stubs should be placed in the dev dependency group
@@ -60,7 +60,7 @@ dev = [
     {include-group = "lint"},
     {include-group = "doc"},
     "coverage[toml]>=7.11.3",
-    "deptry>=0.24.0",
+    "deptry>=0.24.0; python_version < '4.0'",
     "mypy>=1.18.2",
     "pygments>=2.19.0",
     "pytest>=9.0.0",
@@ -71,7 +71,7 @@ dev = [
 {% if cookiecutter.dependency_manager_tool == "poetry" %}
 [tool.poetry]
 classifiers = ["{{cookiecutter.development_status}}"]
-requires-poetry = ">=2.2"
+requires-poetry = ">=2.3"
 {% if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') %}
 packages = [{ include = "{{cookiecutter.package_name}}", from = "src" }]
 {% endif %}
@@ -129,7 +129,7 @@ quiet = true
 force-exclude = true  # Apply excludes to pre-commit
 show-fixes = true
 src = ["src", "tests"]
-target-version = "py311"  # Minimum Python version supported
+target-version = "py313"  # Minimum Python version supported
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 extend-exclude = [
     "__pycache__",

--- a/{{cookiecutter.project_name}}/sonar-project.properties
+++ b/{{cookiecutter.project_name}}/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.host.url=https://sonarcloud.io
 sonar.sources=src/{{cookiecutter.package_name}}/
 sonar.tests=tests/
 
-sonar.python.version=3.11
+sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Remove support for python 3.10 and 3.11
- Use python 3.13 as default python version
- Remove upper limit for required python version, to be compliant with [ADR0032](https://adr.ssb.no/0032-python-versjoner/).
  - Note: If you have dependencies that have <4.0 as upper limit, you either have to set that upper limit on the dependency in `pyproject.toml`, or change to `requires-python = ">=3.102,<4.0"`.