### PR TITLE
Replace GHA salsify/action-detect-and-tag-new-version

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -55,20 +55,79 @@ jobs:
 
       - name: Check if there is a parent commit
         id: check-parent-commit
+        shell: bash
         run: |
-          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          if git rev-parse --verify --quiet HEAD^ >/dev/null; then
+            echo "has-parent=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse --verify HEAD^)" >> "$GITHUB_OUTPUT"
+            echo "Parent commit detected: true"
+          else
+            echo "has-parent=false" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "Parent commit detected: false"
+          fi
 
       - name: Detect and tag new version
         id: check-version
-        if: steps.check-parent-commit.outputs.sha
-        uses: salsify/action-detect-and-tag-new-version@v2.0.3
-        with:
-          version-command: |
-{% if cookiecutter.dependency_manager_tool == "poetry" %}
-            bash -o pipefail -c "poetry version | cut -f 2 -d' '"
-{% else %}
-            uv version --short
-{% endif %}
+        if: steps.check-parent-commit.outputs.has-parent == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read_version_from_file() {
+            python - "$1" <<'PY'
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path(sys.argv[1]).read_text())
+          version = (
+              data.get("project", {}).get("version")
+              or data.get("tool", {}).get("poetry", {}).get("version")
+          )
+
+          if not version:
+              raise SystemExit("Could not find version in [project] or [tool.poetry]")
+
+          print(version)
+          PY
+          }
+
+          PREVIOUS_VERSION="$(read_version_from_file <(git show HEAD~1:pyproject.toml))"
+          CURRENT_VERSION="$(read_version_from_file pyproject.toml)"
+
+          echo "Previous version: $PREVIOUS_VERSION"
+          echo "Current version: $CURRENT_VERSION"
+
+          echo "previous-version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+            echo "Version has not changed; nothing to tag."
+            exit 0
+          fi
+
+          TAG="v$CURRENT_VERSION"
+
+          git fetch --tags
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Creating tag $TAG"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG" -m "Released version $CURRENT_VERSION"
+          git push origin "$TAG"
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Bump version for developmental release
         if: (!steps.check-version.outputs.tag)


### PR DESCRIPTION
This PR fixes #70.

It replaces use of the unmaintained [salsify/action-detect-and-tag-new-version](https://github.com/salsify/action-detect-and-tag-new-version) in `release.yml` with custom code. 

**Note:** According to GitHub the old `release.yml` GitHub Action will not work after June 16th, 2026. This is because the salsify GitHub Action uses Node.js 20, and Node.js 24 is default from that date. You need to upgrade to the new template version to be able to create releases after June 16th, 2026.