### PR TITLE
Release 2026.5.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in [Statistics Norway].
 Use [Cruft] to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.2.24
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.5.27
 ```
 
 Cruft downloads the template, and asks you a series of questions about project variables,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ Here is a detailed list of features for this Python template:
 
 The {{ SPT }} uses [Calendar Versioning] with a `YYYY.MM.DD` versioning scheme.
 
-The current stable release is [2026.2.24].
+The current stable release is [2026.5.27].
 
 (installation)=
 
@@ -219,10 +219,10 @@ pipx upgrade uv
 
 Create a project from this template
 by pointing Cruft to its [GitHub repository][ssb pypi template].
-Use the `--checkout` option with the [current stable release][2026.2.24]:
+Use the `--checkout` option with the [current stable release][2026.5.27]:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.2.24
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.5.27
 ```
 
 Cruft downloads the template,
@@ -2398,7 +2398,7 @@ You can also read the articles on [this blog][hypermodern python blog].
 [.github/dependabot.yml]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 [.gitignore]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [.readthedocs.yml]: https://docs.readthedocs.io/en/stable/config-file/v2.html
-[2026.2.24]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2026.2.24
+[2026.5.27]: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2026.5.27
 [__main__]: https://docs.python.org/3/library/__main__.html
 [abstract syntax tree]: https://docs.python.org/3/library/ast.html
 [actions/cache]: https://github.com/actions/cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ and adopted for use in [Statistics Norway].
 Use [Cruft](https://cruft.github.io/cruft/) to create and update an instance of this template.
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.2.24
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.5.27
 ```
 
 To check if there are there are template updates and update your instance with

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,7 @@ It is recommended to set up Python 3.12, 3.13 and 3.14 using [pyenv].
 Generate a Python project:
 
 ```console
-cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.2.24
+cruft create https://github.com/statisticsnorway/ssb-pypitemplate.git --checkout=2026.5.27
 ```
 
 Cruft downloads the template and asks you a series of questions about project variables.


### PR DESCRIPTION
## Changes

* Replace GHA salsify/action-detect-and-tag-new-version (#109) @arneso-ssb
  * Note: You need to upgrade to the new template version to be able to create releases after June 16th, 2026.
* Security improvements (#108) @arneso-ssb
  * Use 7 days cooldown period when updating dependencies with poetry, uv and dependabot
  * Pin all GitHub Actions to commit SHAs
  * Tighten permission scope in GitHub Actions
